### PR TITLE
Typo fix in the "Colors" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ N/A
 - Base Color - `#FFFFFF` (White)
 - Outline Color - `#4D4D4D` (Breeze)
 
-### BreezeX Dark
+### BreezeX Black
 
 - Base Color - `#000000` (Black)
 - Outline Color - `#FFFFFF` (White)


### PR DESCRIPTION
Fixed a typo where the BreezeX **Black** was mixed with BreezeX **Dark**